### PR TITLE
Feat/expense type module

### DIFF
--- a/src/expense-type/dto/create-expense-type.dto.ts
+++ b/src/expense-type/dto/create-expense-type.dto.ts
@@ -1,7 +1,17 @@
 import { IsBoolean, IsNotEmpty, IsNumber, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
+/**
+ * DTO for creating expense types
+ *
+ * @class
+ * @description Defines the data structure for creating a new expense type
+ */
 export class CreateExpenseTypeDto {
+  /**
+   * Name of the expense type
+   * @example "Food"
+   */
   @ApiProperty({
     description: 'Name of the expense type',
     example: 'Food',
@@ -10,6 +20,10 @@ export class CreateExpenseTypeDto {
   @IsNotEmpty()
   name: string;
 
+  /**
+   * Flag indicating if this expense type is available to all users
+   * @example false
+   */
   @ApiProperty({
     description: 'Whether this expense type is available to all users',
     example: false,
@@ -18,6 +32,10 @@ export class CreateExpenseTypeDto {
   @IsNotEmpty()
   isGlobal: boolean;
 
+  /**
+   * ID of the user who created this expense type
+   * @example 1
+   */
   @ApiProperty({
     description: 'ID of the user who created this expense type',
     example: 1,

--- a/src/expense-type/dto/create-expense-type.dto.ts
+++ b/src/expense-type/dto/create-expense-type.dto.ts
@@ -1,14 +1,27 @@
 import { IsBoolean, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateExpenseTypeDto {
+  @ApiProperty({
+    description: 'Name of the expense type',
+    example: 'Food',
+  })
   @IsString()
   @IsNotEmpty()
   name: string;
 
+  @ApiProperty({
+    description: 'Whether this expense type is available to all users',
+    example: false,
+  })
   @IsBoolean()
   @IsNotEmpty()
   isGlobal: boolean;
 
+  @ApiProperty({
+    description: 'ID of the user who created this expense type',
+    example: 1,
+  })
   @IsNumber()
   @IsNotEmpty()
   userId: number;

--- a/src/expense-type/dto/update-expense-type.dto.ts
+++ b/src/expense-type/dto/update-expense-type.dto.ts
@@ -1,4 +1,11 @@
 import { PartialType } from '@nestjs/swagger';
 import { CreateExpenseTypeDto } from './create-expense-type.dto';
 
+/**
+ * DTO for updating expense types
+ *
+ * @class
+ * @description Defines the data structure for updating an existing expense type
+ * @extends {PartialType<CreateExpenseTypeDto>}
+ */
 export class UpdateExpenseTypeDto extends PartialType(CreateExpenseTypeDto) {}

--- a/src/expense-type/dto/update-expense-type.dto.ts
+++ b/src/expense-type/dto/update-expense-type.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { PartialType } from '@nestjs/swagger';
 import { CreateExpenseTypeDto } from './create-expense-type.dto';
 
 export class UpdateExpenseTypeDto extends PartialType(CreateExpenseTypeDto) {}

--- a/src/expense-type/entities/expense-type.entity.ts
+++ b/src/expense-type/entities/expense-type.entity.ts
@@ -1,1 +1,0 @@
-export class ExpenseType {}

--- a/src/expense-type/expense-type.controller.ts
+++ b/src/expense-type/expense-type.controller.ts
@@ -1,17 +1,57 @@
 import { Controller, Get, Post, Body, Param } from '@nestjs/common';
 import { ExpenseTypeService } from './expense-type.service';
 import { CreateExpenseTypeDto } from './dto/create-expense-type.dto';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBody,
+} from '@nestjs/swagger';
 
+@ApiTags('Expense Types')
 @Controller('type/expense')
 export class ExpenseTypeController {
   constructor(private readonly expenseTypeService: ExpenseTypeService) {}
 
   @Post()
+  @ApiOperation({ summary: 'Create a new expense type' })
+  @ApiBody({ type: CreateExpenseTypeDto })
+  @ApiResponse({
+    status: 201,
+    description: 'The expense type has been successfully created',
+    schema: {
+      properties: {
+        id: { type: 'number' },
+        name: { type: 'string' },
+        isGlobal: { type: 'boolean' },
+        userId: { type: 'number' },
+      },
+    },
+  })
+  @ApiResponse({ status: 400, description: 'Bad request' })
   create(@Body() createExpenseTypeDto: CreateExpenseTypeDto) {
     return this.expenseTypeService.create(createExpenseTypeDto);
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'Find all expense types available to a user' })
+  @ApiParam({ name: 'id', description: 'User ID', type: 'number' })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns array of expense types',
+    schema: {
+      type: 'array',
+      items: {
+        properties: {
+          id: { type: 'number' },
+          name: { type: 'string' },
+          isGlobal: { type: 'boolean' },
+          userId: { type: 'number', nullable: true },
+        },
+      },
+    },
+  })
   findAll(@Param('id') id: string) {
     return this.expenseTypeService.findAll(+id);
   }

--- a/src/expense-type/expense-type.controller.ts
+++ b/src/expense-type/expense-type.controller.ts
@@ -9,11 +9,34 @@ import {
   ApiBody,
 } from '@nestjs/swagger';
 
+/**
+ * Controller for expense type operations
+ *
+ * @class
+ * @description Manages HTTP requests related to expense types
+ */
 @ApiTags('Expense Types')
 @Controller('type/expense')
 export class ExpenseTypeController {
   constructor(private readonly expenseTypeService: ExpenseTypeService) {}
 
+  /**
+   * Create a new expense type
+   *
+   * @param {CreateExpenseTypeDto} createExpenseTypeDto - Data for creating the expense type
+   * @returns {Promise<ExpenseType>} The created expense type
+   * @example
+   * // Example usage with Fetch API
+   * fetch('/api/type/expense', {
+   *   method: 'POST',
+   *   headers: { 'Content-Type': 'application/json' },
+   *   body: JSON.stringify({
+   *     name: "Groceries",
+   *     isGlobal: false,
+   *     userId: 1
+   *   })
+   * })
+   */
   @Post()
   @ApiOperation({ summary: 'Create a new expense type' })
   @ApiBody({ type: CreateExpenseTypeDto })
@@ -34,6 +57,15 @@ export class ExpenseTypeController {
     return this.expenseTypeService.create(createExpenseTypeDto);
   }
 
+  /**
+   * Find all expense types available to a user
+   *
+   * @param {string} id - User ID
+   * @returns {Promise<ExpenseType[]>} Array of expense types
+   * @example
+   * // Example usage with Fetch API
+   * fetch('/api/type/expense/1')
+   */
   @Get(':id')
   @ApiOperation({ summary: 'Find all expense types available to a user' })
   @ApiParam({ name: 'id', description: 'User ID', type: 'number' })

--- a/src/expense-type/expense-type.module.ts
+++ b/src/expense-type/expense-type.module.ts
@@ -3,6 +3,12 @@ import { ExpenseTypeService } from './expense-type.service';
 import { ExpenseTypeController } from './expense-type.controller';
 import { PrismaService } from 'src/prisma/prisma.service';
 
+/**
+ * Expense Type Module
+ *
+ * @module
+ * @description Configures and integrates expense type components
+ */
 @Module({
   controllers: [ExpenseTypeController],
   providers: [ExpenseTypeService, PrismaService],

--- a/src/expense-type/expense-type.service.ts
+++ b/src/expense-type/expense-type.service.ts
@@ -2,16 +2,45 @@ import { Injectable } from '@nestjs/common';
 import { CreateExpenseTypeDto } from './dto/create-expense-type.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
 
+/**
+ * Service for managing expense types
+ *
+ * @class
+ * @description Handles operations related to expense types like creation and retrieval
+ */
 @Injectable()
 export class ExpenseTypeService {
   constructor(private readonly prisma: PrismaService) {}
 
+  /**
+   * Create a new expense type
+   *
+   * @param {CreateExpenseTypeDto} createExpenseTypeDto - Data for creating a new expense type
+   * @returns {Promise<ExpenseType>} The created expense type
+   * @example
+   * // Usage example
+   * this.expenseTypeService.create({
+   *   name: "Groceries",
+   *   isGlobal: false,
+   *   userId: 1
+   * })
+   */
   create(createExpenseTypeDto: CreateExpenseTypeDto) {
     return this.prisma.expenseType.create({
       data: createExpenseTypeDto,
     });
   }
 
+  /**
+   * Find all expense types available to a user
+   *
+   * @param {number} userId - ID of the user
+   * @returns {Promise<ExpenseType[]>} Array of expense types available to the user
+   * @description Returns global expense types and user-specific expense types
+   * @example
+   * // Usage example
+   * this.expenseTypeService.findAll(1)
+   */
   async findAll(userId: number) {
     return await this.prisma.expenseType.findMany({
       where: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ async function bootstrap() {
     .setDescription('API para la gestión de finanzas personales')
     .setVersion('1.0')
     .addTag('Authentication')
+    .addTag('Expense Types')
     .addTag('Users')
     .addTag('Expenses')
     .addTag('Incomes')

--- a/test/expense-type/expense-type.controller.spec.ts
+++ b/test/expense-type/expense-type.controller.spec.ts
@@ -1,0 +1,70 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CreateExpenseTypeDto } from 'src/expense-type/dto/create-expense-type.dto';
+import { ExpenseTypeController } from 'src/expense-type/expense-type.controller';
+import { ExpenseTypeService } from 'src/expense-type/expense-type.service';
+
+describe('ExpenseTypeController', () => {
+  let controller: ExpenseTypeController;
+
+  const mockExpenseTypeService = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ExpenseTypeController],
+      providers: [
+        {
+          provide: ExpenseTypeService,
+          useValue: mockExpenseTypeService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<ExpenseTypeController>(ExpenseTypeController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create an expense type', async () => {
+      const createDto: CreateExpenseTypeDto = {
+        name: 'Food',
+        isGlobal: false,
+        userId: 1,
+      };
+
+      const expectedResult = {
+        id: 1,
+        ...createDto,
+      };
+
+      mockExpenseTypeService.create.mockResolvedValue(expectedResult);
+
+      const result = await controller.create(createDto);
+
+      expect(result).toEqual(expectedResult);
+      expect(mockExpenseTypeService.create).toHaveBeenCalledWith(createDto);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all expense types for a user', async () => {
+      const userId = '1';
+      const expectedTypes = [
+        { id: 1, name: 'Food', isGlobal: false, userId: 1 },
+        { id: 2, name: 'Transport', isGlobal: true, userId: null },
+      ];
+
+      mockExpenseTypeService.findAll.mockResolvedValue(expectedTypes);
+
+      const result = await controller.findAll(userId);
+
+      expect(result).toEqual(expectedTypes);
+      expect(mockExpenseTypeService.findAll).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/test/expense-type/expense-type.controller.spec.ts
+++ b/test/expense-type/expense-type.controller.spec.ts
@@ -3,6 +3,13 @@ import { CreateExpenseTypeDto } from 'src/expense-type/dto/create-expense-type.d
 import { ExpenseTypeController } from 'src/expense-type/expense-type.controller';
 import { ExpenseTypeService } from 'src/expense-type/expense-type.service';
 
+/**
+ * Test suite for ExpenseTypeController
+ *
+ * @group unit
+ * @group expense-type
+ * @description Tests all endpoints of the expense type controller
+ */
 describe('ExpenseTypeController', () => {
   let controller: ExpenseTypeController;
 
@@ -25,11 +32,22 @@ describe('ExpenseTypeController', () => {
     controller = module.get<ExpenseTypeController>(ExpenseTypeController);
   });
 
+  /**
+   * Test controller initialization
+   */
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });
 
+  /**
+   * Tests for the create endpoint
+   *
+   * @description Verifies expense type creation endpoint functionality
+   */
   describe('create', () => {
+    /**
+     * Verify that the create endpoint calls service method with correct parameters
+     */
     it('should create an expense type', async () => {
       const createDto: CreateExpenseTypeDto = {
         name: 'Food',
@@ -51,7 +69,15 @@ describe('ExpenseTypeController', () => {
     });
   });
 
+  /**
+   * Tests for the findAll endpoint
+   *
+   * @description Verifies expense type retrieval endpoint functionality
+   */
   describe('findAll', () => {
+    /**
+     * Verify that the findAll endpoint calls service method with correct parameters
+     */
     it('should return all expense types for a user', async () => {
       const userId = '1';
       const expectedTypes = [

--- a/test/expense-type/expense-type.service.spec.ts
+++ b/test/expense-type/expense-type.service.spec.ts
@@ -3,6 +3,13 @@ import { CreateExpenseTypeDto } from 'src/expense-type/dto/create-expense-type.d
 import { ExpenseTypeService } from 'src/expense-type/expense-type.service';
 import { PrismaService } from 'src/prisma/prisma.service';
 
+/**
+ * Test suite for ExpenseTypeService
+ *
+ * @group unit
+ * @group expense-type
+ * @description Tests all functionality of the expense type service
+ */
 describe('ExpenseTypeService', () => {
   let service: ExpenseTypeService;
 
@@ -24,11 +31,22 @@ describe('ExpenseTypeService', () => {
     service = module.get<ExpenseTypeService>(ExpenseTypeService);
   });
 
+  /**
+   * Test service initialization
+   */
   it('should be defined', () => {
     expect(service).toBeDefined();
   });
 
+  /**
+   * Tests for the create method
+   *
+   * @description Verifies expense type creation functionality
+   */
   describe('create', () => {
+    /**
+     * Verify successful expense type creation
+     */
     it('should create an expense type', async () => {
       const createDto: CreateExpenseTypeDto = {
         name: 'Food',
@@ -52,7 +70,15 @@ describe('ExpenseTypeService', () => {
     });
   });
 
+  /**
+   * Tests for the findAll method
+   *
+   * @description Verifies retrieval of expense types for a user
+   */
   describe('findAll', () => {
+    /**
+     * Verify retrieval of both global and user-specific expense types
+     */
     it('should return all expense types for a user', async () => {
       const userId = 1;
       const expectedTypes = [

--- a/test/expense-type/expense-type.service.spec.ts
+++ b/test/expense-type/expense-type.service.spec.ts
@@ -1,0 +1,75 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CreateExpenseTypeDto } from 'src/expense-type/dto/create-expense-type.dto';
+import { ExpenseTypeService } from 'src/expense-type/expense-type.service';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+describe('ExpenseTypeService', () => {
+  let service: ExpenseTypeService;
+
+  const mockPrismaService = {
+    expenseType: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExpenseTypeService,
+        { provide: PrismaService, useValue: mockPrismaService },
+      ],
+    }).compile();
+
+    service = module.get<ExpenseTypeService>(ExpenseTypeService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create an expense type', async () => {
+      const createDto: CreateExpenseTypeDto = {
+        name: 'Food',
+        isGlobal: false,
+        userId: 1,
+      };
+
+      const expectedResult = {
+        id: 1,
+        ...createDto,
+      };
+
+      mockPrismaService.expenseType.create.mockResolvedValue(expectedResult);
+
+      const result = await service.create(createDto);
+
+      expect(result).toEqual(expectedResult);
+      expect(mockPrismaService.expenseType.create).toHaveBeenCalledWith({
+        data: createDto,
+      });
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all expense types for a user', async () => {
+      const userId = 1;
+      const expectedTypes = [
+        { id: 1, name: 'Food', isGlobal: false, userId },
+        { id: 2, name: 'Transport', isGlobal: true, userId: null },
+      ];
+
+      mockPrismaService.expenseType.findMany.mockResolvedValue(expectedTypes);
+
+      const result = await service.findAll(userId);
+
+      expect(result).toEqual(expectedTypes);
+      expect(mockPrismaService.expenseType.findMany).toHaveBeenCalledWith({
+        where: {
+          OR: [{ isGlobal: true }, { isGlobal: false, userId }],
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces a comprehensive implementation for managing expense types, including DTOs, a controller, a service, Swagger documentation, and unit tests. The changes enhance the modularity, functionality, and test coverage of the expense type feature.

### Feature Implementation:

* **DTOs for Expense Types**:
  - Added `CreateExpenseTypeDto` with Swagger decorators for API documentation, defining fields like `name`, `isGlobal`, and `userId`.
  - Added `UpdateExpenseTypeDto` extending `PartialType` from `@nestjs/swagger` for partial updates.

* **Controller and Service**:
  - Implemented `ExpenseTypeController` with endpoints for creating and retrieving expense types, including Swagger documentation for operations, parameters, and responses.
  - Implemented `ExpenseTypeService` to handle business logic for creating and retrieving expense types, integrating with Prisma.

* **Entity Definition**:
  - Placeholder `ExpenseType` entity removed to prepare for future implementation.

### Documentation and Modular Enhancements:

* **Swagger Integration**:
  - Added `@ApiTags` and operation-specific decorators to the controller for detailed Swagger documentation.
  - Updated Swagger setup in `main.ts` to include the "Expense Types" tag.

* **Module Configuration**:
  - Documented `ExpenseTypeModule` to describe its purpose and integration of components.

### Testing:

* **Unit Tests**:
  - Added unit tests for `ExpenseTypeController` to verify functionality of `create` and `findAll` endpoints.
  - Added unit tests for `ExpenseTypeService` to validate business logic for creating and retrieving expense types.